### PR TITLE
Update to fetch from https://tools.wmflabs.org/openstack-browser/

### DIFF
--- a/project-dsh-generator.py
+++ b/project-dsh-generator.py
@@ -5,7 +5,7 @@ for runnign administrative actions on all hosts in a particular
 labs project. Salt is just way too unreliable to be useful
 for this purpose.
 
-Hits the wikitech API.
+Hits the openstack-browser API.
 
 You can execute commands via pssh like:
 
@@ -17,24 +17,21 @@ import json
 import sys
 from urllib.request import urlopen
 
+OSB = 'https://tools.wmflabs.org/openstack-browser'
 
 project_spec = sys.argv[1]
 
 if project_spec == 'all-instances':
-    projects_url = 'https://wikitech.wikimedia.org/w/api.php?action=query&list=novaprojects&format=json'
-    projects = json.loads(urlopen(projects_url).read().decode('utf-8'))['query']['novaprojects']
+    projects_url = '{}/api/projects.txt'.format(OSB)
+    projects = urlopen(projects_url).read().decode('utf-8').split('\n')
 else:
     projects = [project_spec]
 
 instances = []
 for project_name in projects:
-    api_url = 'https://wikitech.wikimedia.org/w/api.php' \
-              '?action=query&list=novainstances&niregion=eqiad&format=json' \
-              '&niproject=%s' % project_name
-
-    data = json.loads(urlopen(api_url).read().decode('utf-8'))
-    for instance in data['query']['novainstances']:
-        instances.append(instance['name'] + ".eqiad.wmflabs")
+    api_url = '{}/api/dsh/project/{}'.format(OSB, project_name)
+    hosts = urlopen(api_url).read().decode('utf-8').split('\n')
+    instances.extend(hosts)
 
 with open(project_spec, 'w') as f:
     f.write("\n".join(instances))

--- a/tools-dsh-generator.py
+++ b/tools-dsh-generator.py
@@ -1,13 +1,13 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Simple script that generates hosts files usable with dsh/pssh
 for runnign administrative actions on a bunch of toollabs hosts
 at the same time. Salt is just way too unreliable to be useful
 for this purpose.
 
-Hits the wikitech API and then classifies instances into different
-groups based on their names. Update classifier here when things
-change, to keep this useful.
+Hits the openstack-browser API and then classifies instances into different
+groups based on their names. Update classifier here when things change, to
+keep this useful.
 
 You can execute commands via pssh like:
 
@@ -21,39 +21,40 @@ from urllib.request import urlopen
 
 # Maps prefixes to hostgroup names
 classifier = {
-    'webgrid-': 'webgrid-all',
-    'webgrid-lighttpd-': 'webgrid-lighttpd-all',
-    'webgrid-lighttpd-12': 'webgrid-lighttpd-precise',
-    'webgrid-lighttpd-14': 'webgrid-lighttpd-trusty',
-    'webgrid-generic': 'webgrid-generic',
-    'exec-': 'exec-all',
-    'webproxy-': 'webproxy',
+    '': 'all'
+    'bastion-': 'bastion',
     'checker-': 'checker',
+    'cron-': 'cron',
+    'docker-': 'docker',
+    'elastic-': 'elastic',
+    'exec-': 'exec-all',
+    'flannel-': 'flannel',
+    'k8s-': 'k8s',
+    'mail': 'mail',
+    'master': 'master',
+    'proxy-': 'proxy',
     'redis-': 'redis',
     'services-': 'services',
-    'bastion-': 'bastion',
-    'submit': 'submit',
-    'master': 'master',
-    'shadow': 'shadow',
-    'mail': 'mail',
     'static-': 'static',
-    '': 'all'
+    'webgrid-': 'webgrid-all',
+    'webgrid-generic': 'webgrid-generic',
+    'webgrid-lighttpd-': 'webgrid-lighttpd-all',
+    'webgrid-lighttpd-14': 'webgrid-lighttpd-trusty',
+    'worker-': 'worker',
 }
+
+OSB = 'https://tools.wmflabs.org/openstack-browser'
 
 # Initialize hostgroups with empty list
 hostgroups = {name: [] for name in classifier.values()}
 
-api_url = 'https://wikitech.wikimedia.org/w/api.php' \
-          '?action=query&list=novainstances&niregion=eqiad&format=json' \
-          '&niproject=tools'
+api_url = '{}/api/dsh/project/tools'.format(OSB)
+hosts = urlopen(api_url).read().decode('utf-8').split('\n')
 
-data = json.loads(urlopen(api_url).read().decode('utf-8'))
-
-for instance in data['query']['novainstances']:
-    name = instance['name']
+for instance in hosts:
     for prefix in classifier:
-        if name.startswith('tools-' + prefix):
-            hostgroups[classifier[prefix]].append(name + ".eqiad.wmflabs")
+        if instance.startswith('tools-{}'.format(prefix)):
+            hostgroups[classifier[prefix]].append(instance)
 
 for groupname, hosts in hostgroups.items():
     with open(groupname, 'w') as f:


### PR DESCRIPTION
Replace calls to the defunct SMW API with the new hotness of the
openstack-browser tool. Also update tools classifiers for the modern
naming conventions and interesting host groups.